### PR TITLE
Fix: Windows App Icon

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,6 +14,7 @@
       {
         "label": "main",
         "title": "CloudHealth Pricebook Studio",
+        "icon": "icons/icon.ico",
         "width": 1400,
         "height": 900,
         "resizable": true,


### PR DESCRIPTION
Explicitly sets the icon in the window configuration to ensure it's embedded in the Windows executable.