### PR TITLE
Fix: Invalid Icon Property in CI

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,6 @@
       {
         "label": "main",
         "title": "CloudHealth Pricebook Studio",
-        "icon": "icons/icon.ico",
         "width": 1400,
         "height": 900,
         "resizable": true,


### PR DESCRIPTION
Removes 'icon' property from app > windows.