### PR TITLE
Fix: Windows Icon Priority

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -28,12 +28,15 @@
     "active": true,
     "targets": "all",
     "icon": [
+      "icons/icon.ico",
       "icons/32x32.png",
       "icons/128x128.png",
       "icons/128x128@2x.png",
-      "icons/icon.icns",
-      "icons/icon.ico"
-    ]
+      "icons/icon.icns"
+    ],
+    "windows": {
+      "iconPath": "icons/icon.ico"
+    }
   },
   "plugins": {
     "updater": {


### PR DESCRIPTION
Prioritizes icon.ico in the icon array and sets an explicit iconPath for Windows.