### PR TITLE
Fix: Sequential Workflow Jobs

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -90,6 +90,7 @@ jobs:
             -exec gh release upload "$TAG" {} --clobber \;
 
   build-windows:
+    needs: build-linux
     permissions:
       contents: write
     runs-on: windows-latest


### PR DESCRIPTION
Adds needs: build-linux to the build-windows job so they run sequentially.