### PR TITLE
Fix: Tauri Conf Validation Error

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -33,10 +33,7 @@
       "icons/128x128.png",
       "icons/128x128@2x.png",
       "icons/icon.icns"
-    ],
-    "windows": {
-      "iconPath": "icons/icon.ico"
-    }
+    ]
   },
   "plugins": {
     "updater": {


### PR DESCRIPTION
Removes the invalid bundle > windows > iconPath property which was causing the tauri build command to crash during configuration validation.