### PR TITLE
docs: update release checklist to clarify Create Release and Tauri build trigger rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ To maintain high-quality releases, follow this checklist sequentially before and
    - Updated file download list and architectural tables matching the exact version release tag (e.g., swapping `5.5.0` to the new version).
 3. **Keep `README.md` Current**: Ensure all feature summaries, setup steps, and local build details match any new capabilities or CLI commands.
 4. **Trigger Release Action**:
-   - Manually run the **Create Release** workflow on GitHub.
+   - **CRITICAL**: Only run the **Create Release** workflow on GitHub when there is a brand-new release version to publish (i.e. when version numbers are being bumped). Do not trigger it for general feature merges or patches within the same release.
    - The action will automatically read the updated `RELEASE_NOTES.md`, substitute dynamic version placeholders, stamp `CHANGELOG.md` inside the release commit, and create the tagged draft release.
 5. **Publish Platform Assets**:
-   - Manually trigger **Tauri Build** (or wait for the automated release trigger) to compile and upload Windows and Linux release assets.
+   - **CRITICAL**: Go to GitHub Actions and manually trigger the **Tauri Build** workflow, supplying the release tag (e.g., `v5.5.0`), to compile and upload Windows and Linux release assets.
    - Upload macOS installer binaries to the latest release page (e.g., via `gh release upload`).
 
 ---
@@ -91,7 +91,7 @@ Once your code modifications have been pushed to GitHub, complete the following 
 3. **Merge Pull Request**: 
    - Merge the PR into the `main` branch once all checks are green.
 4. **Trigger Release Action**:
-   - Run the **Create Release** workflow in GitHub Actions (selecting the `main` branch and providing the target version, e.g., `v5.5.0`).
+   - **CRITICAL**: Run the **Create Release** workflow in GitHub Actions (selecting the `main` branch and providing the target version, e.g., `v5.5.0`) **only when a new release version is being introduced**.
    - If executed on `main`, the stamped `CHANGELOG.md` will be pushed to a dedicated `release/v5.5.0` branch. Open a quick PR to merge this changelog update back into `main`.
 5. **Sync macOS Desktop Assets**:
    - Build macOS binaries locally using `./build-release.sh`.
@@ -100,7 +100,7 @@ Once your code modifications have been pushed to GitHub, complete the following 
      gh release upload v5.5.0 release/Tauri/CloudHealth.Pricebook.Studio_5.5.0_amd64.dmg release/Tauri/CloudHealth.Pricebook.Studio_5.5.0_arm64.dmg --clobber
      ```
 6. **Trigger Cloud Tauri Builds (Windows & Linux)**:
-   - Go to GitHub Actions, trigger the **Tauri Build** workflow, and supply the release tag (`v5.5.0`). 
+   - Go to GitHub Actions, manually trigger the **Tauri Build** workflow, and supply the release tag (`v5.5.0`). 
    - The workflow will automatically compile the portable Windows executable and Linux packages (`.deb`, `.rpm`, `.AppImage`) and attach them to the release assets.
 7. **Verify Web Deployment**:
    - Verify that the updated web app has been successfully pushed and is live on the **GitHub Pages Preview** branch.


### PR DESCRIPTION
Updates the release checklist in README.md to emphasize that the Create Release workflow should only be run for new version introductions, and clearly highlights the step to manually trigger the Tauri build.