### PR TITLE
fix: correct RPM asset naming to use underscore before arch suffix

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -66,7 +66,7 @@ jobs:
             new_name="${new_name/x64/amd64}"
             
             if [[ "$new_name" == *".rpm"* ]]; then
-              new_name="${new_name/-1./.}"
+              new_name="${new_name/-1._/_}"
               new_name="${new_name//-/_}"
             fi
             


### PR DESCRIPTION
The Linux RPM rename logic in tauri-build.yml was substituting `-1.` with `.` (a dot), producing `CloudHealth.Pricebook.Studio_5.5.0.amd64.rpm` — inconsistent with all other assets which use underscores (`_amd64`).\n\nFix: replace `-1.` with `_` so the output is `CloudHealth.Pricebook.Studio_5.5.0_amd64.rpm`.\n\nThe live release asset for v5.5.0 has also been corrected manually (old asset deleted, correctly named one uploaded).