### PR TITLE
fix: resolve incorrect filename formatting for Tauri amd64.rpm in GitHub Actions

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -66,7 +66,7 @@ jobs:
             new_name="${new_name/x64/amd64}"
             
             if [[ "$new_name" == *".rpm"* ]]; then
-              new_name="${new_name/-1._/_}"
+              new_name=$(echo "$new_name" | sed -E 's/-[0-9]+\.(amd64|x86_64)\.rpm$/_amd64.rpm/')
               new_name="${new_name//-/_}"
             fi
             


### PR DESCRIPTION
This PR fixes the renaming pattern for the Linux RPM in the Tauri Build workflow. Currently, it was being renamed to CloudHealth.Pricebook.Studio_5.5.0_1.amd64.rpm instead of CloudHealth.Pricebook.Studio_5.5.0_amd64.rpm because the pattern matching for `-1.amd64.rpm` did not trigger correctly. This sed command dynamically strips out build numbers and properly maps the arch suffix.