### PR TITLE
fix: hide ready to deploy button on web/gh-pages builds

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -668,7 +668,7 @@ function App() {
             )}
 
             {/* Ready to Deploy button */}
-            {(() => {
+            {isDesktopApp() && (() => {
               const isUpdate = !!state.priceBook?.cxAPIId;
               const color    = isUpdate ? '#38bdf8' : '#10b981';      // cyan : emerald
               const colorRgb = isUpdate ? '56,189,248' : '16,185,129';


### PR DESCRIPTION
## Summary
Wraps the Ready to Deploy button in the Rule Builder with an isDesktopApp() conditional check. Since the Deploy view is only available on desktop platforms (Tauri/local dev), this ensures the button does not show when running on web-only deployments such as GitHub Pages.