### PR TITLE
chore: bump version to 5.5.4 in tauri.conf.json

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CloudHealth Pricebook Studio",
-  "version": "5.5.0",
+  "version": "5.5.4",
   "identifier": "com.cloudhealth.pricebook.studio",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Bumps tauri.conf.json version to match package.json (v5.5.4) so Tauri packaging works correctly.